### PR TITLE
Add support for matching patterns. Such release/* or dev-*.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,15 @@ To force checks (disables skipping), add the third param with `true`:
 grunt.registerTask("deploy", ["test", "checkbranch:develop:true", "copy"]
 ```
 
+Use the 'wildcard' `*` to match a branch prefix or suffix:
+
+```js
+grunt.registerTask("deploy", ["stage", "checkbranch:release/*", "copy"]
+```
+
+
 ## Contributors ##
 
 * [Dominykas Blyžė](https://www.dominykas.com/)
 * [Daniel Lowes](https://github.com/Pleochism)
+* [Stephen Harris](https://github.com/stephenharris)

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "test": "grunt --verbose"
   },
   "dependencies": {
-    "shelljs": "0.7.x"
+    "shelljs": "0.7.x",
+    "minimatch": "3.0.x"
   },
   "devDependencies": {
     "buster": "0.7.x",

--- a/tasks/checkbranch.js
+++ b/tasks/checkbranch.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var shell = require("shelljs");
+var minimatch = require("minimatch");
 
 module.exports = function (grunt) {
 
@@ -25,12 +26,11 @@ module.exports = function (grunt) {
 			if (e) {
 				grunt.fail.fatal("Failed to detect the current branch");
 			}
-
 			var branch = branchOutput.trim();
-			if (!negate && branch !== expectedBranch) {
+			if (!negate && !minimatch(branch, expectedBranch)) {
 				grunt.fail.fatal("Only '" + expectedBranch + "' branch is allowed, and you're on '" + branch + "' branch.");
 			}
-			else if (negate && branch === expectedBranch) {
+			else if (negate && minimatch(branch, expectedBranch) ) {
 				grunt.fail.fatal("Anything except '" + expectedBranch + "' branch is allowed, and you're on '" + branch + "' branch.");
 			}
 

--- a/test/checkbranch.test.js
+++ b/test/checkbranch.test.js
@@ -96,6 +96,46 @@ buster.testCase("grunt-checkbranch", {
 		expect(output.stdout).toMatch(GRUNT_FATAL);
 		expect(output.stdout).toMatch("Failed to detect");
 		expect(output.code).toEqual(1, "Incorrect grunt output code");
-	}
+	},
+
+	"should proceed when branch matches pattern": function () {
+		shell.pushd('tmp');
+		shell.exec("git checkout -b release/1.2.3");
+		shell.popd();
+
+		var output = execGrunt("checkbranch:release/*");
+		expect(output.stdout).toMatch(GRUNT_SUCCESS);
+		expect(output.code).toEqual(0, "Incorrect grunt output code");
+	},
+
+	"should not proceed when branch does not match pattern": function () {
+		shell.pushd('tmp');
+		shell.exec("git checkout -b release");
+		shell.popd();
+
+		var output = execGrunt("checkbranch:release/*");
+		expect(output.stdout).toMatch(GRUNT_FATAL);
+		expect(output.code).toEqual(1, "Incorrect grunt output code");
+	},
+
+	"should proceed when branch does not match negated pattern": function () {
+		shell.pushd('tmp');
+		shell.exec("git checkout -b master");
+		shell.popd();
+
+		var output = execGrunt("checkbranch:!dev-*");
+		expect(output.stdout).toMatch(GRUNT_SUCCESS);
+		expect(output.code).toEqual(0, "Incorrect grunt output code");
+	},
+
+	"should not proceed when branch matches negated pattern": function () {
+		shell.pushd('tmp');
+		shell.exec("git checkout -b release/1.2.3");
+		shell.popd();
+
+		var output = execGrunt("checkbranch:!release/*");
+		expect(output.stdout).toMatch(GRUNT_FATAL);
+		expect(output.code).toEqual(1, "Incorrect grunt output code");
+	},
 
 });


### PR DESCRIPTION
This allows users to exclude a 'family' of branches without knowing
the branch names. For example, allowing only deployment to a staging
environment from a branch beginning with "release/"

Includes tests.
